### PR TITLE
Don't Send Explicit Terminate Output of Server

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/ember/core/core.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/ember/core/core.scala
@@ -82,7 +82,6 @@ package object core {
                 .covary[F]
                 .flatMap(Encoder.respToBytes[F])
                 .through(socket.writes())
-                .onFinalize(socket.endOfOutput)
                 .compile
                 .drain
                 .attempt


### PR DESCRIPTION
Server should not send end of output, as clients can reuse the socket if they want.